### PR TITLE
fix: remove User-Agent header to fix CORS preflight

### DIFF
--- a/src/views/SearchView.vue
+++ b/src/views/SearchView.vue
@@ -85,7 +85,6 @@ const doSearch = async (q) => {
     const response = await ky.get('https://lrclib.net/api/search', {
       searchParams: { q },
       headers: {
-        'User-Agent': 'LRCLIB Web Client (https://github.com/tranxuanthang/lrclib)',
         'X-User-Agent': 'LRCLIB Web Client (https://github.com/tranxuanthang/lrclib)',
         'Lrclib-Client': 'LRCLIB Web Client (https://github.com/tranxuanthang/lrclib)',
       }


### PR DESCRIPTION
## Summary
- Removes the `User-Agent` header from API requests made by the `ky` HTTP client
- `User-Agent` is a forbidden header name in the Fetch spec and cannot be overridden from browser JavaScript
- Including it in the request causes the browser to request CORS permission for it in the preflight, but the lrclib.net server does not whitelist `user-agent` in `Access-Control-Allow-Headers`
- The remaining headers (`X-User-Agent`, `Lrclib-Client`) are already whitelisted by the server

*Generated by Kimi K2.6 with human oversight.*