### PR TITLE
feat: add dark mode support via Tailwind dark: variants

### DIFF
--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -2,8 +2,12 @@
 @tailwind components;
 @tailwind utilities;
 
+:root {
+  color-scheme: light dark;
+}
+
 body {
-  @apply bg-indigo-100 text-indigo-900;
+  @apply bg-indigo-100 text-indigo-900 dark:bg-indigo-900 dark:text-slate-100;
 }
 
 .button {
@@ -11,9 +15,9 @@ body {
 }
 
 .button-normal {
-  @apply bg-indigo-200 hover:bg-indigo-300 text-indigo-900 active:bg-indigo-400;
+  @apply bg-indigo-200 hover:bg-indigo-300 text-indigo-900 active:bg-indigo-400 dark:bg-slate-800 dark:hover:bg-slate-700 dark:text-slate-100 dark:active:bg-slate-600;
 }
 
 .button-blend {
-  @apply hover:bg-indigo-300 text-indigo-900 active:bg-indigo-400;
+  @apply hover:bg-indigo-300 text-indigo-900 active:bg-indigo-400 dark:hover:bg-slate-700 dark:text-slate-100 dark:active:bg-slate-600;
 }

--- a/src/components/ApiBlock.vue
+++ b/src/components/ApiBlock.vue
@@ -1,12 +1,12 @@
 <template>
-  <div class="bg-indigo-50 rounded overflow-hidden shadow-lg">
-    <h2 class="text-xl bg-indigo-200 p-4"><slot name="title" /></h2>
+  <div class="bg-indigo-50 rounded overflow-hidden shadow-lg dark:bg-slate-900">
+    <h2 class="text-xl bg-indigo-200 p-4 dark:bg-slate-800 dark:text-slate-100"><slot name="title" /></h2>
     <div class="p-4">
-      <div class="bg-indigo-200 rounded flex p-1 gap-1 mb-8">
-        <div class="bg-indigo-700 rounded p-1 font-bold uppercase text-white"><slot name="method" /></div>
-        <div class="p-1 grow"><slot name="route" /></div>
+      <div class="bg-indigo-200 rounded flex p-1 gap-1 mb-8 dark:bg-slate-800">
+        <div class="bg-indigo-700 rounded p-1 font-bold uppercase text-white dark:bg-indigo-500"><slot name="method" /></div>
+        <div class="p-1 grow dark:text-slate-100"><slot name="route" /></div>
       </div>
-      <div class="prose prose-indigo">
+      <div class="prose prose-indigo dark:prose-invert">
         <slot name="description" />
       </div>
     </div>

--- a/src/components/Donation.vue
+++ b/src/components/Donation.vue
@@ -1,28 +1,28 @@
 <template>
   <div>
     <div class="fixed top-0 left-0 h-full w-full flex items-center justify-center z-30 p-4">
-      <div class="w-full h-[80vh] max-w-screen-sm rounded-lg bg-white flex flex-col gap-2">
+      <div class="w-full h-[80vh] max-w-screen-sm rounded-lg bg-white flex flex-col gap-2 dark:bg-slate-800">
         <div class="flex-none flex justify-between items-center px-6 py-2">
-          <div class="text-thin text-xl">Donation</div>
+          <div class="text-thin text-xl dark:text-slate-100">Donation</div>
           <button class="button button-blend transition rounded-full p-4" @click="close"><Close /></button>
         </div>
 
         <div class="px-6 grow flex flex-col gap-4 overflow-scroll">
           <div class="flex justify-center">
-            <div class="rounded-full p-1 bg-indigo-100 flex justify-center gap-1">
+            <div class="rounded-full p-1 bg-indigo-100 flex justify-center gap-1 dark:bg-slate-700">
               <button
                 class="button text-xs w-36 px-3 py-1.5 rounded-full"
                 :class="{
-                  'bg-indigo-800 text-indigo-100': donationChoice === 'buymeacoffee',
-                  'hover:bg-indigo-200': donationChoice !== 'buymeacoffee'
+                  'bg-indigo-800 text-indigo-100 dark:bg-indigo-300 dark:text-indigo-900': donationChoice === 'buymeacoffee',
+                  'hover:bg-indigo-200 dark:hover:bg-slate-600': donationChoice !== 'buymeacoffee'
                   }"
                 @click="donationChoice = 'buymeacoffee'"
               >Fiat</button>
               <button
                 class="button text-xs w-36 px-3 py-1.5 rounded-full"
                 :class="{
-                  'bg-indigo-800 text-indigo-100': donationChoice === 'cryptocurrency',
-                  'hover:bg-indigo-200': donationChoice !== 'cryptocurrency'
+                  'bg-indigo-800 text-indigo-100 dark:bg-indigo-300 dark:text-indigo-900': donationChoice === 'cryptocurrency',
+                  'hover:bg-indigo-200 dark:hover:bg-slate-600': donationChoice !== 'cryptocurrency'
                   }"
                 @click="donationChoice = 'cryptocurrency'"
               >Cryptocurrency</button>
@@ -31,18 +31,18 @@
 
           <div class="grow flex flex-col">
             <div v-if="donationChoice === 'buymeacoffee'" class="w-full flex flex-col items-center">
-              <div class="text-center italic text-xs mb-4">Thank you for being here!
+              <div class="text-center italic text-xs mb-4 dark:text-slate-300">Thank you for being here!
                 LRCLIB is always free and nonprofit.
                 However, maintaining and developing LRCLIB requires both time and financial resources.
                 If you can, please consider a donation—every amount, no matter how small, is appreciated!</div>
 
-              <div class="text-center font-thin text-2xl mb-4">GitHub Sponsors</div>
+              <div class="text-center font-thin text-2xl mb-4 dark:text-slate-100">GitHub Sponsors</div>
 
-              <a href="https://github.com/sponsors/tranxuanthang" class="mb-8" target="_blank">
+              <a href="https://github.com/sponsors/tranxuanthang" class="mb-8 dark:text-indigo-300" target="_blank">
                 https://github.com/sponsors/tranxuanthang
               </a>
 
-              <div class="text-center font-thin text-2xl mb-4">Buy Me A Coffee</div>
+              <div class="text-center font-thin text-2xl mb-4 dark:text-slate-100">Buy Me A Coffee</div>
 
               <a href="https://www.buymeacoffee.com/thangtran" class="mb-8" target="_blank">
                 <img
@@ -51,26 +51,26 @@
                   height="72"
                 /></a>
 
-              <div class="text-center font-thin text-2xl mb-4">Paypal</div>
+              <div class="text-center font-thin text-2xl mb-4 dark:text-slate-100">Paypal</div>
 
-              <a href="https://paypal.me/tranxuanthang98" class="mb-8" target="_blank">
+              <a href="https://paypal.me/tranxuanthang98" class="mb-8 dark:text-indigo-300" target="_blank">
                 https://paypal.me/tranxuanthang98
               </a>
             </div>
 
             <div v-if="donationChoice === 'cryptocurrency'">
-              <div class="text-center italic text-xs mb-4">Thank you for being here!
+               <div class="text-center italic text-xs mb-4 dark:text-slate-300">Thank you for being here!
                 LRCLIB is always free and nonprofit.
                 However, maintaining and developing LRCLIB requires both time and financial resources.
                 If you can, please consider a donation—every amount, no matter how small, is appreciated!</div>
 
-              <div class="text-center font-thin text-2xl mb-4">Monero (XMR)</div>
+              <div class="text-center font-thin text-2xl mb-4 dark:text-slate-100">Monero (XMR)</div>
 
-              <div class="bg-indigo-900 rounded px-4 py-2 text-indigo-100 break-all mb-8">43ZN5qDdGQhPGthFnngD8rjCHYLsEFBcyJjDC1GPZzVxWSfT8R48QCLNGyy6Z9LvatF5j8kSgv23DgJpixJg8bnmMnKm3b7</div>
+              <div class="bg-indigo-900 rounded px-4 py-2 text-indigo-100 break-all mb-8 dark:bg-indigo-950 dark:text-indigo-200">43ZN5qDdGQhPGthFnngD8rjCHYLsEFBcyJjDC1GPZzVxWSfT8R48QCLNGyy6Z9LvatF5j8kSgv23DgJpixJg8bnmMnKm3b7</div>
 
-              <div class="text-center font-thin text-2xl mb-4">Litecoin (LTC)</div>
+              <div class="text-center font-thin text-2xl mb-4 dark:text-slate-100">Litecoin (LTC)</div>
 
-              <div class="bg-indigo-900 rounded px-4 py-2 text-indigo-100 break-all">ltc1q7texq5qsp59gclqlwf6asrqmhm98gruvz94a48</div>
+              <div class="bg-indigo-900 rounded px-4 py-2 text-indigo-100 break-all dark:bg-indigo-950 dark:text-indigo-200">ltc1q7texq5qsp59gclqlwf6asrqmhm98gruvz94a48</div>
             </div>
           </div>
         </div>
@@ -81,7 +81,7 @@
       </div>
     </div>
 
-    <div class="fixed top-0 left-0 h-full w-full z-20 bg-black/30">
+    <div class="fixed top-0 left-0 h-full w-full z-20 bg-black/30 dark:bg-black/50">
     </div>
   </div>
 </template>

--- a/src/components/Preview.vue
+++ b/src/components/Preview.vue
@@ -1,21 +1,21 @@
 <template>
   <div>
     <div class="fixed top-0 left-0 h-full w-full flex items-center justify-center z-30 p-4">
-      <div class="w-full h-[80vh] max-w-screen-sm rounded-lg bg-white flex flex-col gap-2">
+      <div class="w-full h-[80vh] max-w-screen-sm rounded-lg bg-white flex flex-col gap-2 dark:bg-slate-800">
         <div class="flex-none flex justify-between items-center px-6 py-2">
-          <div class="text-thin text-xl">Preview</div>
+          <div class="text-thin text-xl dark:text-slate-100">Preview</div>
           <button class="button button-blend transition rounded-full p-4" @click="close"><Close /></button>
         </div>
 
         <div class="px-6 grow flex flex-col justify-between gap-4 overflow-hidden">
           <div v-if="props.record.syncedLyrics && props.record.plainLyrics" class="flex justify-center">
-            <div class="rounded-full p-1 bg-indigo-100 flex justify-center gap-1">
+            <div class="rounded-full p-1 bg-indigo-100 flex justify-center gap-1 dark:bg-slate-700">
               <button class="button text-xs w-36 px-3 py-1.5 rounded-full"
-                      :class="{ 'bg-indigo-800 text-indigo-100': lyricsType === 'synced', 'hover:bg-indigo-200': lyricsType !== 'synced' }"
+                      :class="{ 'bg-indigo-800 text-indigo-100 dark:bg-indigo-300 dark:text-indigo-900': lyricsType === 'synced', 'hover:bg-indigo-200 dark:hover:bg-slate-600': lyricsType !== 'synced' }"
                       @click="lyricsType = 'synced'">Synced Lyrics
               </button>
               <button class="button text-xs w-36 px-3 py-1.5 rounded-full"
-                      :class="{ 'bg-indigo-800 text-indigo-100': lyricsType !== 'synced', 'hover:bg-indigo-200': lyricsType === 'synced' }"
+                      :class="{ 'bg-indigo-800 text-indigo-100 dark:bg-indigo-300 dark:text-indigo-900': lyricsType !== 'synced', 'hover:bg-indigo-200 dark:hover:bg-slate-600': lyricsType === 'synced' }"
                       @click="lyricsType = 'plain'">Plain Lyrics
               </button>
             </div>
@@ -23,23 +23,23 @@
 
           <div class="relative grow flex flex-col justify-between overflow-hidden">
             <button v-if="props.record.syncedLyrics || props.record.plainLyrics"
-                    class="absolute bottom-4 right-8 p-4 rounded-full bg-indigo-700 hover:bg-indigo-800 active:bg-indigo-950 transition text-indigo-200"
+                    class="absolute bottom-4 right-8 p-4 rounded-full bg-indigo-700 hover:bg-indigo-800 active:bg-indigo-950 transition text-indigo-200 dark:bg-indigo-300 dark:hover:bg-indigo-200 dark:active:bg-indigo-100 dark:text-indigo-900"
                     @click="copyToClipboard">
               <ContentCopy/>
             </button>
-            <div v-if="lyricsType === 'synced'" class="grow rounded bg-indigo-50 text-indigo-900 whitespace-pre-line p-4 overflow-auto">
+            <div v-if="lyricsType === 'synced'" class="grow rounded bg-indigo-50 text-indigo-900 whitespace-pre-line p-4 overflow-auto dark:bg-slate-700 dark:text-slate-100">
               {{ props.record.syncedLyrics }}
             </div>
 
-            <div v-else-if="lyricsType === 'plain'" class="grow rounded bg-indigo-50 text-indigo-900 whitespace-pre-line p-4 overflow-auto">
+            <div v-else-if="lyricsType === 'plain'" class="grow rounded bg-indigo-50 text-indigo-900 whitespace-pre-line p-4 overflow-auto dark:bg-slate-700 dark:text-slate-100">
               {{ props.record.plainLyrics }}
             </div>
 
-            <div v-else-if="lyricsType === 'instrumental'" class="grow rounded bg-indigo-50 text-indigo-900 whitespace-pre-line p-4 overflow-auto italic flex items-center justify-center">
+            <div v-else-if="lyricsType === 'instrumental'" class="grow rounded bg-indigo-50 text-indigo-900 whitespace-pre-line p-4 overflow-auto italic flex items-center justify-center dark:bg-slate-700 dark:text-slate-100">
               This track is instrumental
             </div>
 
-            <div v-else class="grow rounded bg-indigo-50 text-indigo-900 whitespace-pre-line p-4 overflow-auto italic flex items-center justify-center">
+            <div v-else class="grow rounded bg-indigo-50 text-indigo-900 whitespace-pre-line p-4 overflow-auto italic flex items-center justify-center dark:bg-slate-700 dark:text-slate-100">
               There are currently no lyrics submitted for this track
             </div>
           </div>
@@ -51,7 +51,7 @@
       </div>
     </div>
 
-    <div class="fixed top-0 left-0 h-full w-full z-20 bg-black/30">
+    <div class="fixed top-0 left-0 h-full w-full z-20 bg-black/30 dark:bg-black/50">
     </div>
   </div>
 </template>

--- a/src/views/DatabaseDumpsView.vue
+++ b/src/views/DatabaseDumpsView.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="min-h-screen py-6 px-2 mx-auto w-full max-w-screen-sm">
     <div class="text-sm mb-8">
-      <router-link to="/" class="text-indigo-400 hover:text-indigo-500 active:text-indigo-700 transition flex items-center uppercase gap-2">
+      <router-link to="/" class="text-indigo-400 hover:text-indigo-500 active:text-indigo-700 transition flex items-center uppercase gap-2 dark:text-slate-400 dark:hover:text-slate-300 dark:active:text-slate-200">
         <ArrowLeft />
         <span>Back to home</span>
       </router-link>
@@ -18,7 +18,7 @@
         <div
           v-for="dump in dumps"
           :key="dump.key"
-          class="bg-indigo-50 hover:bg-white transition px-4 py-2 rounded flex justify-between items-center"
+          class="bg-indigo-50 hover:bg-white transition px-4 py-2 rounded flex justify-between items-center dark:bg-slate-900 dark:hover:bg-slate-800"
         >
           <div class="flex flex-col gap-2">
             <div class="flex-grow truncate">
@@ -31,14 +31,14 @@
 
             <div class="flex gap-1 items-center">
               <div class="text-xs whitespace-nowrap">{{ humanFileSize(dump.size) }}</div>
-              <div class="text-xs text-indigo-300">|</div>
+              <div class="text-xs text-indigo-300 dark:text-slate-600">|</div>
               <div class="text-xs whitespace-nowrap">{{ dayjs(dump.uploaded).fromNow() }}</div>
             </div>
           </div>
 
           <div class="flex items-center">
             <a
-              class="rounded text-indigo-700 hover:bg-indigo-800 active:bg-indigo-950 transition p-3 hover:text-indigo-100 active:text-indigo-100"
+              class="rounded text-indigo-700 hover:bg-indigo-800 active:bg-indigo-950 transition p-3 hover:text-indigo-100 active:text-indigo-100 dark:text-indigo-300 dark:hover:bg-indigo-200 dark:hover:text-indigo-900 dark:active:bg-indigo-100"
               :href="`https://db-dumps.lrclib.net/${dump.key}`"
               target="_blank"
             ><Download /></a>

--- a/src/views/DocsView.vue
+++ b/src/views/DocsView.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="min-h-screen py-6 px-2 mx-auto w-full max-w-screen-sm">
     <div class="text-sm mb-8">
-      <router-link to="/" class="text-indigo-400 hover:text-indigo-500 active:text-indigo-700 transition flex items-center uppercase gap-2">
+      <router-link to="/" class="text-indigo-400 hover:text-indigo-500 active:text-indigo-700 transition flex items-center uppercase gap-2 dark:text-slate-400 dark:hover:text-slate-300 dark:active:text-slate-200">
         <ArrowLeft />
         <span>Back to home</span>
       </router-link>
@@ -9,7 +9,7 @@
 
     <h1 class="block font-thin text-2xl mb-16">API Documentation</h1>
 
-    <div class="mb-16 prose prose-indigo">
+    <div class="mb-16 prose prose-indigo dark:prose-invert">
       <p>
         Welcome to the beta API documentation and specification of the LRCLIB's API!
         Although we intend to maintain backward compatibility, please be aware that there may be breaking changes in future updates.
@@ -75,7 +75,7 @@
           </p>
 
           <h4>Example response</h4>
-          <p class="text-green-800">200 OK:</p>
+          <p class="text-green-800 dark:text-green-300">200 OK:</p>
           <p>
             <pre class="whitespace-pre-wrap">{
   &quot;id&quot;: 3396226,
@@ -89,7 +89,7 @@
 }</pre>
           </p>
 
-          <p class="text-red-800">404 Not Found:</p>
+          <p class="text-red-800 dark:text-red-300">404 Not Found:</p>
           <p>
             <pre class="whitespace-pre-wrap">{
   &quot;code&quot;: 404,
@@ -296,8 +296,8 @@
           </p>
 
           <h4>Response</h4>
-          <p class="text-green-800">Success response: 201 Created</p>
-          <p class="text-red-800">Failed response (incorrect Publish Token):</p>
+          <p class="text-green-800 dark:text-green-300">Success response: 201 Created</p>
+          <p class="text-red-800 dark:text-red-300">Failed response (incorrect Publish Token):</p>
           <p>
             <pre class="whitespace-pre-wrap">{
   &quot;code&quot;: 400,

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -3,10 +3,10 @@
     <main class="w-full max-w-screen-sm">
       <div class="flex flex-col justify-center items-center gap-6 w-full">
         <img src="@/assets/lrclib.png" width="512" height="512" class="w-28" alt="Logo">
-        <form class="flex items-center rounded-full w-full h-auto overflow-hidden bg-white transition" :class="{ 'ring ring-indigo-400': inputActive }" @submit.prevent="onSubmit">
-          <input type="text" v-model="keyword" class="outline-none grow h-12 px-6" placeholder="Search for lyrics..." @focus="inputActive = true" @blur="inputActive = false" autofocus>
+        <form class="flex items-center rounded-full w-full h-auto overflow-hidden bg-white dark:bg-slate-900 transition" :class="{ 'ring ring-indigo-400 dark:ring-indigo-400': inputActive }" @submit.prevent="onSubmit">
+          <input type="text" v-model="keyword" class="outline-none grow h-12 px-6 bg-transparent" placeholder="Search for lyrics..." @focus="inputActive = true" @blur="inputActive = false" autofocus>
           <button
-            class="rounded-full bg-indigo-700 hover:bg-indigo-800 active:bg-indigo-950 transition text-indigo-200 text-lg h-12 w-12 flex justify-center items-center m-1"
+            class="rounded-full bg-indigo-700 hover:bg-indigo-800 active:bg-indigo-950 transition text-indigo-200 text-lg h-12 w-12 flex justify-center items-center m-1 dark:bg-indigo-300 dark:hover:bg-indigo-200 dark:active:bg-indigo-100 dark:text-indigo-900"
           >
             <Magnify />
           </button>
@@ -55,10 +55,10 @@ const onSubmit = () => {
 
 <style scoped>
 .link {
-  @apply rounded-lg px-3 py-1.5 text-xs text-indigo-600 hover:bg-indigo-50 transition;
+  @apply rounded-lg px-3 py-1.5 text-xs text-indigo-600 hover:bg-indigo-50 transition dark:text-indigo-300 dark:hover:bg-indigo-950 dark:hover:text-indigo-100;
 }
 
 .link-highlight {
-  @apply rounded-lg px-3 py-1.5 text-xs text-indigo-700 bg-indigo-50 hover:bg-indigo-800 hover:text-indigo-50 transition font-bold;
+  @apply rounded-lg px-3 py-1.5 text-xs text-indigo-700 bg-indigo-50 hover:bg-indigo-800 hover:text-indigo-50 transition font-bold dark:text-indigo-200 dark:bg-indigo-950 dark:hover:bg-indigo-800 dark:hover:text-indigo-50;
 }
 </style>

--- a/src/views/SearchView.vue
+++ b/src/views/SearchView.vue
@@ -1,16 +1,16 @@
 <template>
   <div class="min-h-screen py-6 px-2 mx-auto w-full max-w-screen-sm flex flex-col">
     <div class="text-sm mb-8">
-      <router-link to="/" class="text-indigo-400 hover:text-indigo-500 active:text-indigo-700 transition flex items-center uppercase gap-2">
+      <router-link to="/" class="text-indigo-400 hover:text-indigo-500 active:text-indigo-700 transition flex items-center uppercase gap-2 dark:text-slate-400 dark:hover:text-slate-300 dark:active:text-slate-200">
         <ArrowLeft />
         <span>Back to home</span>
       </router-link>
     </div>
 
-    <form class="flex items-center rounded-full w-full h-auto overflow-hidden bg-white transition mb-16" :class="{ 'ring ring-indigo-400': inputActive }" @submit.prevent="onSubmit">
-      <input type="text" v-model="keyword" class="outline-none grow h-12 px-6" placeholder="Search for lyrics..." @focus="inputActive = true" @blur="inputActive = false" autofocus>
+    <form class="flex items-center rounded-full w-full h-auto overflow-hidden bg-white dark:bg-slate-900 transition mb-16" :class="{ 'ring ring-indigo-400 dark:ring-indigo-400': inputActive }" @submit.prevent="onSubmit">
+      <input type="text" v-model="keyword" class="outline-none grow h-12 px-6 bg-transparent" placeholder="Search for lyrics..." @focus="inputActive = true" @blur="inputActive = false" autofocus>
       <button
-        class="rounded-full bg-indigo-700 hover:bg-indigo-800 active:bg-indigo-950 transition text-indigo-200 text-lg h-12 w-12 flex justify-center items-center m-1"
+        class="rounded-full bg-indigo-700 hover:bg-indigo-800 active:bg-indigo-950 transition text-indigo-200 text-lg h-12 w-12 flex justify-center items-center m-1 dark:bg-indigo-300 dark:hover:bg-indigo-200 dark:active:bg-indigo-100 dark:text-indigo-900"
       >
         <Magnify />
       </button>
@@ -22,24 +22,24 @@
       <Loading />
     </div>
 
-    <div v-else-if="error" class="grow text-5xl flex justify-center items-center animate-spin text-red-800">
+    <div v-else-if="error" class="grow text-5xl flex justify-center items-center animate-spin text-red-800 dark:text-red-300">
       {{ error }}
     </div>
 
     <div v-else class="flex flex-col gap-4">
-      <div v-for="record in records" :key="record.id" class="bg-indigo-50 hover:bg-white transition px-4 py-2 rounded flex justify-between items-center">
+      <div v-for="record in records" :key="record.id" class="bg-indigo-50 hover:bg-white transition px-4 py-2 rounded flex justify-between items-center dark:bg-slate-900 dark:hover:bg-slate-800">
         <div class="flex flex-col gap-1">
           <div class="font-bold">{{ record.trackName }}</div>
           <div class="text-xs font-bold flex gap-2">
-            <span class="bg-indigo-200 text-indigo-900 px-1 py-0.5 rounded">{{ format(record.duration * 1000) }}</span>
-            <span v-if="!!record.syncedLyrics" class="bg-green-800 text-green-200 px-1 py-0.5 rounded">Synced</span>
-            <span v-else-if="!!record.plainLyrics" class="bg-gray-800 text-gray-200 px-1 py-0.5 rounded">Plain</span>
-            <span v-else-if="!!record.instrumental" class="bg-gray-300 text-gray-600 px-1 py-0.5 rounded">Instrumental</span>
+            <span class="bg-indigo-200 text-indigo-900 px-1 py-0.5 rounded dark:bg-slate-800 dark:text-slate-100">{{ format(record.duration * 1000) }}</span>
+            <span v-if="!!record.syncedLyrics" class="bg-green-800 text-green-200 px-1 py-0.5 rounded dark:bg-green-200 dark:text-green-900">Synced</span>
+            <span v-else-if="!!record.plainLyrics" class="bg-gray-800 text-gray-200 px-1 py-0.5 rounded dark:bg-gray-200 dark:text-gray-900">Plain</span>
+            <span v-else-if="!!record.instrumental" class="bg-gray-300 text-gray-600 px-1 py-0.5 rounded dark:bg-gray-700 dark:text-gray-300">Instrumental</span>
           </div>
           <div class="font-thin">{{ record.albumName }} - {{ record.artistName }}</div>
         </div>
         <div>
-          <button class="rounded text-indigo-700 hover:bg-indigo-800 active:bg-indigo-950 transition p-3 hover:text-indigo-100 active:text-indigo-100" type="button" @click="showingRecord = record"><Eye /></button>
+          <button class="rounded text-indigo-700 hover:bg-indigo-800 active:bg-indigo-950 transition p-3 hover:text-indigo-100 active:text-indigo-100 dark:text-indigo-300 dark:hover:bg-indigo-200 dark:hover:text-indigo-900 dark:active:bg-indigo-100" type="button" @click="showingRecord = record"><Eye /></button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Adds full dark mode support using Tailwind CSS `dark:` variants (media-prefers-color-scheme)
- Sets `color-scheme: light dark` on `:root` in `main.css`
- No configuration changes needed — Tailwind's default `darkMode: 'media'` handles it
- Light mode appearance is completely unchanged

### Files modified (8 files)
- `src/assets/main.css` — body bg/text, `color-scheme`, button class dark variants
- `src/views/HomeView.vue` — search form, search button, scoped `.link`/`.link-highlight` styles
- `src/views/SearchView.vue` — search form, search button, result cards, status badges, view button, error text
- `src/views/DocsView.vue` — back link, `dark:prose-invert`, status colors
- `src/views/DatabaseDumpsView.vue` — back link, dump cards
- `src/components/Donation.vue` — overlay, modal, crypto address rows, copy buttons
- `src/components/Preview.vue` — overlay, modal, copy/close buttons
- `src/components/ApiBlock.vue` — container, title, route bar, method badge, `dark:prose-invert`

### Color mapping
| Role | Light | Dark |
|------|-------|------|
| Body background | indigo-100 | indigo-900 |
| Body-level chips | indigo-50 | indigo-950 |
| Card surfaces | indigo-50 | slate-900 |
| Card hover | white | slate-800 |
| Modals | white | slate-800 |
| Modal sub-fills | indigo-50 | slate-700 |
| Accent buttons (search, copy) | indigo-700/800/950 | indigo-300/200/100 |
| Normal buttons | indigo-200/300/400 | slate-800/700/600 |
| Body text | indigo-900 | slate-100 |
| Prose | prose-indigo | dark:prose-invert |

*Generated by Kimi K2.6. Tested and oversaw by a human.*